### PR TITLE
Cosmjs test vectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,18 @@ build-simd-all: go.sum
         --name latest-build cosmossdk/rbuilder:latest
 	docker cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
 
+build-simd-darwin: go.sum $(BUILDDIR)/
+	docker rm latest-build || true
+	docker run --volume=$(CURDIR):/sources:ro \
+		--env TARGET_PLATFORMS='darwin/amd64' \
+		--env APP=simd \
+		--env VERSION=$(VERSION) \
+		--env COMMIT=$(COMMIT) \
+		--env LEDGER_ENABLED=$(LEDGER_ENABLED) \
+		--name latest-build cosmossdk/rbuilder:latest
+	docker cp -a latest-build:/home/builder/artifacts/ $(CURDIR)/
+	cp artifacts/simd-*-darwin-amd64 $(BUILDDIR)/simd
+
 build-simd-linux: go.sum $(BUILDDIR)/
 	docker rm latest-build || true
 	docker run --volume=$(CURDIR):/sources:ro \

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -387,6 +387,7 @@ func Sign(txf Factory, name string, txBuilder client.TxBuilder) error {
 		// use the SignModeHandler's default mode if unspecified
 		signMode = txf.txConfig.SignModeHandler().DefaultMode()
 	}
+	fmt.Printf("Sign Mode: %s\n\n", signMode)
 
 	key, err := txf.keybase.Key(name)
 	if err != nil {
@@ -426,12 +427,14 @@ func Sign(txf Factory, name string, txBuilder client.TxBuilder) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Sign Bytes: %x\n\n", signBytes)
 
 	// Sign those bytes
 	sigBytes, _, err := txf.keybase.Sign(name, signBytes)
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Signature: %x\n\n", sigBytes)
 
 	// Construct the SignatureV2 struct
 	sigData = signing.SingleSignatureData{

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -257,6 +257,13 @@ func makeSignCmd() func(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		// print out the protobuf format
+		proto, err := txCfg.TxEncoder()(txBuilder.GetTx())
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Signed TX Bytes: %x\n", proto)
+
 		json, err := marshalSignatureJSON(txCfg, txBuilder, generateSignatureOnly)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

DO NOT MERGE - just for test output

This is a branch that can be rebased on current versions of cosmos-sdk to produce a `simapp` version that outputs test vectors as requested by https://github.com/CosmWasm/cosmjs/issues/451 (and other issues).

Please see https://github.com/CosmWasm/cosmjs/pull/468 for build instructions on how to generate the test vectors.

This just adds one line of the proto encoded signed tx

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
